### PR TITLE
Reliably fetch tickets on network change

### DIFF
--- a/NoMAD-ADAuth/KerbUtil.h
+++ b/NoMAD-ADAuth/KerbUtil.h
@@ -21,7 +21,7 @@ extern OSStatus SecKeychainItemSetAccessWithPassword(SecKeychainItemRef item, Se
 @interface KerbUtil : NSObject
 @property (nonatomic, assign, readonly) BOOL						finished;   // observable
 
-- (void)getKerbCredentials:(NSString *)password :(NSString *)userPrincipal completion:(void(^)(NSString *))callback;
+- (void)getKerberosCredentials:(NSString *)password :(NSString *)userPrincipal completion:(void(^)(NSString *))callback;
 - (NSString *)getKerbCredentials:(NSString *)password :(NSString *)userPrincipal;
 - (NSString *)changeKerbPassword:(NSString *)oldPassword :(NSString *)newPassword :(NSString *)userPrincipal;
 - (int)checkPassword:(NSString *)myPassword;

--- a/NoMAD-ADAuth/KerbUtil.h
+++ b/NoMAD-ADAuth/KerbUtil.h
@@ -21,6 +21,7 @@ extern OSStatus SecKeychainItemSetAccessWithPassword(SecKeychainItemRef item, Se
 @interface KerbUtil : NSObject
 @property (nonatomic, assign, readonly) BOOL						finished;   // observable
 
+- (void)getKerbCredentials:(NSString *)password :(NSString *)userPrincipal completion:(void(^)(NSString *))callback;
 - (NSString *)getKerbCredentials:(NSString *)password :(NSString *)userPrincipal;
 - (NSString *)changeKerbPassword:(NSString *)oldPassword :(NSString *)newPassword :(NSString *)userPrincipal;
 - (int)checkPassword:(NSString *)myPassword;

--- a/NoMAD-ADAuth/KerbUtil.m
+++ b/NoMAD-ADAuth/KerbUtil.m
@@ -30,7 +30,7 @@ extern OSStatus SecKeychainChangePassword(SecKeychainRef keychainRef, UInt32 old
 
 extern OSStatus SecKeychainResetLogin(UInt32 passwordLength, const void* password, Boolean resetSearchList);
 
-- (void)getKerbCredentials:(NSString *)password :(NSString *)userPrincipal completion:(void(^)(NSString *))callback {
+- (void)getKerberosCredentials:(NSString *)password :(NSString *)userPrincipal completion:(void(^)(NSString *))callback {
     OM_uint32 maj_stat;
     gss_name_t gname = GSS_C_NO_NAME;
     gss_cred_id_t cred = NULL;

--- a/NoMAD-ADAuth/KerbUtil.m
+++ b/NoMAD-ADAuth/KerbUtil.m
@@ -49,7 +49,7 @@ extern OSStatus SecKeychainResetLogin(UInt32 passwordLength, const void* passwor
     CFRelease(gname);
     if (maj_stat) {
         NSLog(@"error: %d %@", (int)maj_stat, error);
-        NSDictionary *errorDict = CFBridgingRelease(CFErrorCopyUserInfo(error)) ;
+        NSDictionary *errorDict = CFBridgingRelease(CFErrorCopyUserInfo(error));
         NSString *errorMessage = [errorDict valueForKey:(@"NSDescription")];
         callback(errorMessage);
         return;

--- a/NoMAD-ADAuth/KlistUtil.swift
+++ b/NoMAD-ADAuth/KlistUtil.swift
@@ -73,7 +73,8 @@ public class KlistUtil {
     public func returnDefaultExpiration() -> Date? {
         return defaultExpires
     }
-    
+
+    /// Note this will kill any pre-existing tickets for this user.
     public func klist() {
         
         let sema = DispatchSemaphore(value: 0)
@@ -172,7 +173,11 @@ public class KlistUtil {
         }
         //print(tickets)
     }
-    
+
+    public func hasTickets(principal: String) -> Bool {
+        tickets.keys.sorted().map { $0.lowercased() }.contains(principal.lowercased())
+    }
+
     // function to delete a kerb ticket
     
     public func kdestroy(princ: String = "" ) {

--- a/NoMAD-ADAuth/NoMADSession.swift
+++ b/NoMAD-ADAuth/NoMADSession.swift
@@ -1065,24 +1065,24 @@ extension NoMADSession: NoMADUserSession {
         }
 
         let kerbUtil = KerbUtil()
-        kerbUtil.getKerbCredentials(userPass, userPrincipal) { [unowned self] error in
-            userPass = ""
-            if let error = error {
-                state = .kerbError
+        kerbUtil.getKerbCredentials(userPass, userPrincipal) { [unowned self] errorValue in
+            self.userPass = ""
+            if let errorValue = errorValue {
+                self.state = .kerbError
                 let sessionError: NoMADSessionError
-                switch error {
+                switch errorValue {
                 case NoMADSessionError.PasswordExpired.rawValue:
                     sessionError = .PasswordExpired
                 case NoMADSessionError.wrongRealm.rawValue:
                     sessionError = .wrongRealm
-                case _ where error.contains("unable to reach any KDC in realm"):
+                case _ where errorValue.contains("unable to reach any KDC in realm"):
                     sessionError = .OffDomain
                 default:
                     sessionError = .KerbError
                 }
                 completion(.failure(sessionError))
             } else {
-                processKerberosResult(completion: completion)
+                self.processKerberosResult(completion: completion)
             }
         }
     }

--- a/NoMAD-ADAuth/NoMADSession.swift
+++ b/NoMAD-ADAuth/NoMADSession.swift
@@ -1056,6 +1056,7 @@ public class NoMADSession : NSObject {
 }
 
 extension NoMADSession: NoMADUserSession {
+
     public func getKerberosTicket(principal: String? = nil, completion: @escaping (KerberosTicketResult) -> Void) {
         // Check if system already has tickets
         if let principal = principal, klistUtil.hasTickets(principal: principal) {
@@ -1064,7 +1065,7 @@ extension NoMADSession: NoMADUserSession {
         }
 
         let kerbUtil = KerbUtil()
-        kerbUtil.getKerbCredentials(userPass, userPrincipal) { [unowned self] errorValue in
+        kerbUtil.getKerberosCredentials(userPass, userPrincipal) { [unowned self] errorValue in
             self.userPass = ""
             if let errorValue = errorValue {
                 self.state = .kerbError
@@ -1092,8 +1093,8 @@ extension NoMADSession: NoMADUserSession {
         // Get ticket
         klistUtil.klist()
 
-        // Check for valid ticket
-        guard klistUtil.returnDefaultPrincipal().contains(kerberosRealm) else {
+        // Check that ticket is valid
+        if !klistUtil.returnDefaultPrincipal().contains(kerberosRealm) && !anonymous {
             completion(.failure(.UnAuthenticated))
             return
         }

--- a/NoMAD-ADAuth/NoMADSession.swift
+++ b/NoMAD-ADAuth/NoMADSession.swift
@@ -66,9 +66,7 @@ public struct NoMADLDAPServer {
 
 /// A general purpose class that is the main entrypoint for interactions with Active Directory.
 public class NoMADSession : NSObject {
-    
-    // variables
-    
+
     public var state: NoMADSessionState = .offDomain          // current state of affairs
     weak public var delegate: NoMADUserSessionDelegate?       // delegate
     public var site: String = ""                              // current AD site
@@ -1059,6 +1057,7 @@ public class NoMADSession : NSObject {
 
 extension NoMADSession: NoMADUserSession {
     public func getKerberosTicket(principal: String? = nil, completion: @escaping (KerberosTicketResult) -> Void) {
+        // Check if system already has tickets
         if let principal = principal, klistUtil.hasTickets(principal: principal) {
             shareKerberosResult(completion: completion)
             return
@@ -1090,10 +1089,10 @@ extension NoMADSession: NoMADUserSession {
     private func processKerberosResult(completion: @escaping (KerberosTicketResult) -> Void) {
         state = .offDomain
 
-        // get ticket
+        // Get ticket
         klistUtil.klist()
 
-        // check for valid ticket
+        // Check for valid ticket
         guard klistUtil.returnDefaultPrincipal().contains(kerberosRealm) else {
             completion(.failure(.UnAuthenticated))
             return

--- a/NoMAD-ADAuth/NoMADSession.swift
+++ b/NoMAD-ADAuth/NoMADSession.swift
@@ -10,7 +10,7 @@ import Foundation
 import NoMADPRIVATE
 
 public protocol NoMADUserSession {
-    func getKerberosTickets(principal: String?)
+    func getTickets(principal: String?)
     func authenticate(authTestOnly: Bool)
     func changePassword()
     func userInfo()
@@ -1064,7 +1064,7 @@ public class NoMADSession : NSObject {
 }
 
 extension NoMADSession: NoMADUserSession {
-    public func getKerberosTickets(principal: String? = nil) {
+    public func getTickets(principal: String? = nil) {
         if let principal = principal, klistUtil.hasTickets(principal: principal) {
             shareKerberosResult()
             return

--- a/README.md
+++ b/README.md
@@ -15,13 +15,25 @@ The NoMAD AD Authentication Framework allows you to present a username and passw
 - is aware of network changes, and will mark sites to be re-discovered on changes
 - perform recursive group lookups
 
-## Basic Usage of the Framework
+## Basic Usage of the Framework via Delegate
 
-- Drag the framework into your project in the Embedded Binaries section of the target.
+- Drag the framework into your project in the Embedded Binaries section of the target
 - Import NoMAD_ADAuth into your class
-- Subclass NoMADUserSessionDelegate, and then add the stubs suggested to conform to the protocol
+- Adopt NoMADUserSessionDelegate, and then add the stubs suggested to conform to the protocol
 - create a NoMADSession object `let session = NoMADSession.init(domain: "nomad.test", user: "ftest@NOMAD.TEST", type: .AD)`
 - set a password on the session object `session.userPass = "Secret1!"`
 - set the session delegate to your class `session.delegate = self`
-- try to authenticate `sesssion.authenticate()`
+- try to authenticate `session.authenticate()`
 - the delegate callbacks will then let you know if the auth succeeded or not
+
+## Basic Usage of the Framework via Closure
+
+- Drag the framework into your project in the Embedded Binaries section of the target
+- Import `NoMAD_ADAuth`
+- Make a `NoMADSession` object via `init(domain: String, user: String, type: LDAPType = .AD)`
+- Set the session's `userPass` variable
+- Call the session's `getKerberosTicket(principal: String? = nil, completion: @escaping (KerberosTicketResult) -> Void)` function
+- If the optional `principal` parameter is supplied, this function tries to fetch an existing ticket for this principal,
+-  and then if unsuccessful, continues by trying to get a new ticket
+- This function shares its result by running the supplied closure upon completion
+-  with `KerberosTicketResult` containing either an `ADUserRecord` on success or a `NoMADSessionError` on failure


### PR DESCRIPTION
Enable simplified use of framework via closure, with fixes that enable user to get Kerberos ticket on network change/check, and without sleep loops